### PR TITLE
Release v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyduckling-native-phihos"
-version = "0.5.0-dev0"
+version = "0.4.1"
 authors = ["Edgar Andrés Margffoy Tuay <andfoy@gmail.com>", "Philipp Hossner <philipp.hossner@posteo.de>"]
 description = "Rust-based Python wrapper for duckling library in Haskell."
 repository = "https://github.com/phihos/pyduckling"


### PR DESCRIPTION
Patch release to publish the missing cp311-manylinux_2_28_x86_64 wheel that was silently dropped from v0.4.0 due to a parallel build race condition.